### PR TITLE
deploy: Decouple html files from httpd container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,0 @@
-FROM quay.io/josh_wood/caddy:latest
-MAINTAINER Josh Wood <j@joshix.com>
-COPY public /var/www/html/
-EXPOSE 80 443 2015
-WORKDIR /var/www/html
-CMD ["/bin/caddy"]
-

--- a/deploy.bash
+++ b/deploy.bash
@@ -5,7 +5,7 @@ SSH=core@jxnu.joshix.com
 
 # Build the site into the public/ directory.
 rm -rf public
-rm public.tgz
+rm -f public.tgz
 hugo
 cp Caddyfile public/Caddyfile
 
@@ -13,17 +13,10 @@ cp Caddyfile public/Caddyfile
 tar czf public.tgz public
 scp public.tgz $SSH:
 rm public.tgz
-scp Dockerfile $SSH:
 
 # Remote server operations. Set up the directory, build the image,
 # and run the container.
 # --warning=no-unknown-keyword quiets gnutar complaints about bsdtar headers.
-ssh $SSH 'rm -rf jxsite && mkdir -p jxsite && \
-mv Dockerfile public.tgz jxsite/ && cd jxsite && \
-tar --warning=no-unknown-keyword -xzf public.tgz && \
-docker build -t josh_wood/jxsite . && \
-cd .. && rm -rf jxsite && \
-docker stop jxsite && \
-docker rm -v jxsite && \
-docker run --name jxsite -d -v /home/core/dotcaddy:/.caddy:rw \
--p 80:80 -p 443:443 josh_wood/jxsite'
+ssh $SSH 'cd jxsite && rm -rf public/* && \
+tar --warning=no-unknown-keyword -xzf ../public.tgz && \
+rm ../public.tgz'


### PR DESCRIPTION
Remove the dockerfile, don't build a container for the site.
Instead, change deploy script to copy just the hugo-generated
public/ dir. The server runs the stock caddybox image.
